### PR TITLE
feat: implement `detect_os`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ executors:
       image: ubuntu-2204:current
 
 jobs:
+  bats-alpine:
+    executor: alpine
+    steps:
+      - checkout
+      - run:
+          name: Install and run BATS
+          command: |
+            apk add bats
+            mkdir /tmp/bats
+            bats --formatter tap --report-formatter junit --output /tmp/bats --timing /root/project
+      - store_test_results:
+          path: /tmp/bats
   detect-os:
     parameters:
       executor:
@@ -66,21 +78,15 @@ workflows:
           matrix:
             alias: bats-detect-os
             parameters:
-              exec_environment: [cimg, mac, ubuntu]
+              exec_environment: [cimg, mac]
           requires: [shellcheck/check]
-      - bats/run:
-          name: bats/run-alpine
-          formatter: junit
-          path: .
-          exec_environment: alpine
+      - bats-alpine:
           requires: [shellcheck/check]
-          pre-steps:
-            - run: apk add git sudo
       - detect-os:
           matrix:
             alias: test-detect-os
             parameters:
               executor: [cimg, mac, alpine, windows, ubuntu]
-          requires: [shellcheck/check, bats-detect-os, bats/run-alpine]
+          requires: [shellcheck/check, bats-detect-os, bats-alpine]
 
 # VS Code Extension Version: 1.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+version: 2.1
+
+orbs:
+  shellcheck: circleci/shellcheck@3
+  bats: circleci/bats@1
+
+executors:
+  cimg:
+    docker:
+      - image: cimg/base:stable
+  mac:
+    macos:
+      xcode: 14.1.0
+  alpine:
+    docker:
+      - image: alpine:latest
+  windows:
+    machine:
+      image: windows-server-2022-gui:current
+      resource_class: windows.medium
+      shell: bash.exe
+  ubuntu:
+    machine:
+      image: ubuntu-2204:current
+
+jobs:
+  detect-os:
+    parameters:
+      executor:
+        type: executor
+    executor: << parameters.executor >>
+    steps:
+      - checkout
+      - run:
+          name: Check if OS is detected correctly
+          command: |
+            # Simulate how cURL fetches the script.
+            detect_os_script="$(cat "${CIRCLE_WORKING_DIRECTORY/\~/$HOME}"/detect_os.sh)"
+
+            # Evaluate the script and invoke the function.
+            eval "$detect_os_script"
+
+            # Helper function to print the result of the test.
+            print_success() { printf '%s\n' "$ORB_UTILS_PLATFORM was detected correctly!"; }
+
+            # This test relies on $CIRCLE_JOB to check if the OS is detected correctly.
+            # If the executor or job name is changed, this test must be updated or it will fail.
+            executor="$(printf '%s' "$CIRCLE_JOB" | sed 's/detect-os-\(.*\)/\1/g')"
+            case "$executor" in
+              windows) [ "$ORB_UTILS_PLATFORM" = "windows" ] && print_success ;;
+              ubuntu) [ "$ORB_UTILS_PLATFORM" = "ubuntu" ] && print_success ;;
+              mac) [ "$ORB_UTILS_PLATFORM" = "macos" ] && print_success ;;
+              cimg) [ "$ORB_UTILS_PLATFORM" = "ubuntu" ] && print_success ;;
+              alpine) [ "$ORB_UTILS_PLATFORM" = "alpine" ] && print_success ;;
+              *) { printf '%s\n' "Failed to detect OS." "Expected: $executor" "Actual: $ORB_UTILS_PLATFORM"; exit 1; } ;;
+            esac
+
+workflows:
+  test:
+    jobs:
+      - detect-os:
+          matrix:
+            alias: test-detect-os
+            parameters:
+              executor: [cimg, mac, alpine, windows, ubuntu]
+
+# VS Code Extension Version: 1.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,5 +64,6 @@ workflows:
             alias: test-detect-os
             parameters:
               executor: [cimg, mac, alpine, windows, ubuntu]
+          requires: [shellcheck/check]
 
 # VS Code Extension Version: 1.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   shellcheck: circleci/shellcheck@3
+  bats: circleci/bats@1
 
 executors:
   cimg:
@@ -59,11 +60,19 @@ workflows:
     jobs:
       - shellcheck/check:
           shell: sh
+      - bats/run:
+          formatter: junit
+          path: .
+          matrix:
+            alias: bats-detect-os
+            parameters:
+              exec_environment: [cimg, mac, alpine, windows, ubuntu]
+          requires: [shellcheck/check]
       - detect-os:
           matrix:
             alias: test-detect-os
             parameters:
               executor: [cimg, mac, alpine, windows, ubuntu]
-          requires: [shellcheck/check]
+          requires: [shellcheck/check, bats-detect-os]
 
 # VS Code Extension Version: 1.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   shellcheck: circleci/shellcheck@3
-  bats: circleci/bats@1
 
 executors:
   cimg:
@@ -58,6 +57,8 @@ jobs:
 workflows:
   test:
     jobs:
+      - shellcheck/check:
+          shell: sh
       - detect-os:
           matrix:
             alias: test-detect-os

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,21 @@ workflows:
           matrix:
             alias: bats-detect-os
             parameters:
-              exec_environment: [cimg, mac, alpine, windows, ubuntu]
+              exec_environment: [cimg, mac, ubuntu]
           requires: [shellcheck/check]
+      - bats/run:
+          name: bats/run-alpine
+          formatter: junit
+          path: .
+          exec_environment: alpine
+          requires: [shellcheck/check]
+          pre-steps:
+            - run: apk add git sudo
       - detect-os:
           matrix:
             alias: test-detect-os
             parameters:
               executor: [cimg, mac, alpine, windows, ubuntu]
-          requires: [shellcheck/check, bats-detect-os]
+          requires: [shellcheck/check, bats-detect-os, bats/run-alpine]
 
 # VS Code Extension Version: 1.2.0

--- a/detect_os.bats
+++ b/detect_os.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+setup() {
+  unset ORB_UTILS_DETECT_OS_VERBOSE
+  unset ORB_UTILS_DETECT_OS_INVOKE
+  OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+  case "$OS_NAME" in
+    linux*) PLATFORM="$(grep -e "^ID=" /etc/os-release | cut -c4-)" ;;
+    darwin*) PLATFORM="macos" ;;
+    msys* | cygwin*) PLATFORM="windows" ;;
+    *) PLATFORM="unknown" ;;
+  esac
+}
+
+@test "detect_os - Detects the OS" {
+  detect_os_script="$(cat "./detect_os.sh")"
+  run eval "$detect_os_script"
+  printf '%s\n' "Expected: $PLATFORM" "Actual: $output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$PLATFORM" ]
+}
+
+@test "detect_os - Print verbose output if \"ORB_UTILS_DETECT_OS_VERBOSE\" is true" {
+  local expected="$(printf '%s\n' "OS name: $OS_NAME" "Platform: $PLATFORM" "$PLATFORM")"
+  local detect_os_script="$(cat "./detect_os.sh")"
+  ORB_UTILS_DETECT_OS_VERBOSE=true
+  run eval "$detect_os_script"
+  printf '%s\n' "Expected: $expected" "Actual: $output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "detect_os - Doesn't invoke the command if \"ORB_UTILS_DETECT_OS_INVOKE\" is false" {
+  ORB_UTILS_DETECT_OS_INVOKE=false
+  local detect_os_script="$(cat "./detect_os.sh")"
+  run eval "$detect_os_script"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}

--- a/detect_os.sh
+++ b/detect_os.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC3043 # While "local" is not POSIX, it is supported by all shells we care about.
+
+# Public: Detect the operating system.
+#
+# Detects the operating system and writes it to ORB_UTILS_PLATFORM. If the OS is
+# linux, the distribution is written instead.
+#
+# ORB_UTILS_DETECT_OS_VERBOSE - Whether to print verbose output. Defaults to false.
+# ORB_UTILS_DETECT_OS_INVOKE - Whether to invoke the function on script execution. Defaults to true.
+#
+# Examples
+#
+#   detect_os
+#   ORB_UTILS_DETECT_OS_VERBOSE=true detect_os
+#   ORB_UTILS_DETECT_OS_INVOKE=false detect_os
+#
+# Writes the OS to stdout, exports to BASH_ENV and returns 0 if the OS is known.
+# Otherwise, returns 1 and writes to stderr.
+detect_os() {
+  ORB_UTILS_DETECT_OS_VERBOSE="${ORB_UTILS_DETECT_OS_VERBOSE:-false}"
+  local verbose="$ORB_UTILS_DETECT_OS_VERBOSE"
+
+  local os_name
+  os_name=$(uname -s | tr '[:upper:]' '[:lower:]')
+  [ "$verbose" = false ] || printf '%s\n' "OS name: $os_name"
+
+  local platform
+  case "$os_name" in
+    linux*) platform="$(grep -e "^ID=" /etc/os-release | cut -c4-)" ;;
+    darwin*) platform="macos" ;;
+    msys* | cygwin*) platform="windows" ;;
+    *) platform="unknown" ;;
+  esac
+  [ "$verbose" = false ] || printf '%s\n' "Platform: $platform"
+
+  # Write to stderr and return 1 if the OS is not known.
+  [ "$platform" = "unknown" ] && { >&2 printf '%s\n' "Could not identify the operating system."; return 1; }
+
+  # Export to make it immediately available to the caller.
+  export ORB_UTILS_PLATFORM="$platform"
+  # Inject into the environment via $BASH_ENV to make it available in other steps.
+  if [ -n "$BASH_ENV" ]; then printf '%s\n' "export ORB_UTILS_PLATFORM=$platform" >> "$BASH_ENV"; fi
+  # Write to stdout and return 0.
+  printf '%s\n' "$platform"
+  return 0
+}
+
+ORB_UTILS_DETECT_OS_INVOKE="${ORB_UTILS_DETECT_OS_INVOKE:-true}"
+[ "$ORB_UTILS_DETECT_OS_INVOKE" = false ] || detect_os


### PR DESCRIPTION
# Standard Proposal

This is my proposal for how orb utility functions should be implemented. I am using `detect_os` for this exercise, but the practices and design decisions should apply to all scripts in this repository. In the following sections, I'll explain the reasoning behind my decisions.

## Documentation

AFAIK there is no industry standard for documenting bash functions. However, some styles accompany scripts that generate markdown or HTML documents. One such style is [tomdoc.sh](https://github.com/tests-always-included/tomdoc.sh). While TomDoc is a documentation specification for Ruby, it fits nicely in bash, and as illustrated by the previous link, there are shell scripts to generate docs from it. Notice how easy it is to understand what the function does without looking into its body:

```bash
# Public: Detect the operating system.
#
# Detects the operating system and writes it to ORB_UTILS_PLATFORM. If the OS is
# linux, the distribution is written instead.
#
# ORB_UTILS_DETECT_OS_VERBOSE - Whether to print verbose output. Defaults to false.
# ORB_UTILS_DETECT_OS_INVOKE - Whether to invoke the function on script execution. Defaults to true.
#
# Examples
#
#   detect_os
#   ORB_UTILS_DETECT_OS_VERBOSE=true detect_os
#   ORB_UTILS_DETECT_OS_INVOKE=false detect_os
#
# Writes the OS to stdout, exports to BASH_ENV and returns 0 if the OS is known.
# Otherwise, returns 1 and writes to stderr.
detect_os() {
...
```

## Invocation

The implementation I'm proposing is very flexible regarding invocation. There are a few ways to go about it:

### One-liner

If the output in stdout/stderr is not required, it's a matter of cURL-ing it and piping it to your shell of preference:

```bash
curl -fsSL https://raw.githubusercontent.com/CircleCI-Public/orb-utils/feat/detect_os/detect_os.sh | bash 
```

But if you need whatever is in stdout, you can capture the output from the subshell:

```bash
my_var="$(curl -fsSL https://raw.githubusercontent.com/CircleCI-Public/orb-utils/feat/detect_os/detect_os.sh | bash)"
```

### cURL and source

You might want to invoke the script in the current shell instead of creating a subshell. If that's the case, you can save the script to a file and source it:

```bash
curl -fsSL https://raw.githubusercontent.com/CircleCI-Public/orb-utils/feat/detect_os/detect_os.sh -o detect_os.sh 
chmod +x detect_os.sh
source detect_os.sh
```

### eval

Another option is to download and evaluate it:

```bash
detect_os_script="$(curl -fsSL https://raw.githubusercontent.com/CircleCI-Public/orb-utils/feat/detect_os/detect_os.sh)"
eval detect_os_script.sh
```

## Output

To make the function as flexible as possible, I am writing to stdout, BASH_ENV and environment. This is only applicable if the function will have an output in the first place, which is the case for `detect_os`:

### stdout

This makes it easier to capture output from a subshell if necessary.

```bash
printf '%s\n' "$platform"
```

### BASH_ENV

The functions in this repo will likely be used only in orbs. But on the off chance that they are helpful outside orb development, I am checking for the existence of a `BASH_ENV` variable before writing to it.

```bash
if [ -n "$BASH_ENV" ]; then printf '%s\n' "export ORB_UTILS_PLATFORM=$platform" >> "$BASH_ENV"; fi
```

### Export to an environment variable

By exporting the variable, we make it immediately available to the caller. Remember that this will only work if the function is not invoked from a subshell, as the parent shell does not have access to its child scope.

```bash
export ORB_UTILS_PLATFORM="$platform"
```

## Parameters

I could only support all invocation methods while accepting parameters using environment variables. I got the inspiration from the CircleCI CLI. The primary issue with this approach is the risk of conflicting variable names, which can lead to value override and unexpected behaviour. I am overcoming this with painfully specific parameter names. Should we choose to follow my proposal, the naming convention for them will be:

```bash
ORB_UTILS_<Function>_<Parameter>
```

In the case of `detect_os`, we have two parameters:

 - ORB_UTILS_DETECT_OS_VERBOSE
 - ORB_UTILS_DETECT_OS_INVOKE

I believe both of them should be included in all functions. The first, `ORB_UTILS_DETECT_OS_VERBOSE`, is a boolean that toggles verbose output in case we need extra information:

```bash
  ORB_UTILS_DETECT_OS_VERBOSE="${ORB_UTILS_DETECT_OS_VERBOSE:-false}"
  local verbose="$ORB_UTILS_DETECT_OS_VERBOSE"

  local os_name
  os_name=$(uname -s | tr '[:upper:]' '[:lower:]')
  [ "$verbose" = false ] || printf '%s\n' "OS name: $os_name"
```

The second, `ORB_UTILS_DETECT_OS_INVOKE`, is a boolean that tells the script whether or not to invoke the function on execution. 

```bash
ORB_UTILS_DETECT_OS_INVOKE="${ORB_UTILS_DETECT_OS_INVOKE:-true}"
[ "$ORB_UTILS_DETECT_OS_INVOKE" = false ] || detect_os
```

Your use case might require invoking the function yourself instead of letting the script do it for you. This parameter exists to allow that kind of flexibility:

```bash
detect_os_script="$(curl -fsSL https://raw.githubusercontent.com/CircleCI-Public/orb-utils/feat/detect_os/detect_os.sh)"
ORB_UTILS_DETECT_OS_INVOKE=false eval detect_os_script.sh
# now the script won't run detect_os. You will have to call it explicitly
detect_os
```

## Return

You will notice no `exit` statements in the function. I believe we should let the decision to end the execution of the process to the caller. The function assists by returning proper error codes and writing to stderr:

```bash
[ "$platform" = "unknown" ] && { >&2 printf '%s\n' "Could not identify the operating system."; return 1; }
```

## Tests

While BATS initially looked like the best option for writing tests, I deviated from it because I wanted to ensure this function worked in as many environments as possible. I achieved that objective by writing a simple test in `config.yml` and running it in multiple executors, including docker with Alpine. Should I do the same with BATS, I would likely have issues running the tests in environments without bash. I am open to discussing this, as I could be wrong. Additionally, writing shell inside YAML is far from ideal.

## Conclusion

Everything in this PR/proposal is up for discussion. Let me know what you think.